### PR TITLE
top level awaitでenvのloadすると参照エラーが起きる問題の調査

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -155,6 +155,7 @@
     "https://deno.land/std@0.190.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
     "https://deno.land/std@0.190.0/regexp/escape.ts": "f5955d785245f6910c262ea2f0a284d2be7a76c54929c3f15f4df8d2a623f1d5",
     "https://deno.land/std@0.190.0/semver/mod.ts": "200f50cf6872212667df532fb09f0b1a33d3427a5201f75fad30a0d0c6dbcce3",
+    "https://deno.land/std@0.208.0/dotenv/mod.ts": "039468f5c87d39b69d7ca6c3d68ebca82f206ec0ff5e011d48205eea292ea5a6",
     "https://deno.land/x/base64@v0.2.1/base.ts": "47dc8d68f07dc91524bdd6db36eccbe59cf4d935b5fc09f27357a3944bb3ff7b",
     "https://deno.land/x/base64@v0.2.1/base64url.ts": "18bbf879b31f1f32cca8adaa2b6885ae325c2cec6a66c5817b684ca12c46ad5e",
     "https://deno.land/x/code_block_writer@11.0.3/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",

--- a/domain/cacheForUpstash.ts
+++ b/domain/cacheForUpstash.ts
@@ -2,20 +2,23 @@ import { Redis } from "https://deno.land/x/upstash_redis@v1.14.0/mod.ts";
 import { load } from "https://deno.land/std@0.208.0/dotenv/mod.ts";
 import { assert } from "https://deno.land/std@0.190.0/_util/asserts.ts";
 
-const env = await load();
+const redisInit = async () => {
+  const env = await load();
 
-const url = env["UPSTASH_URL"];
-const token = env["UPSTASH_TOKEN"];
+  const url = env["UPSTASH_URL"];
+  const token = env["UPSTASH_TOKEN"];
 
-assert(!!url, "UPSTASH_URLがセットされていません");
-assert(!!token, "UPSTASH_TOKENがセットされていません");
+  assert(!!url, "UPSTASH_URLがセットされていません");
+  assert(!!token, "UPSTASH_TOKENがセットされていません");
 
-const redis = new Redis({
-  url,
-  token,
-});
+  return new Redis({
+    url,
+    token,
+  });
+};
 
 export const pushCache = async <T>(key: string, data: T) => {
+  const redis = await redisInit();
   return await redis.set(
     key,
     JSON.stringify({
@@ -26,12 +29,14 @@ export const pushCache = async <T>(key: string, data: T) => {
 };
 
 export const getCache = async <T>(key: string) => {
+  const redis = await redisInit();
   return await redis.get<T>(
     key,
   );
 };
 
 export const deleteCache = async <T>(key: string) => {
+  const redis = await redisInit();
   return await redis.del(
     key,
   );


### PR DESCRIPTION
top level awaitを使うと loadを使ったenvの参照ができないエラーが出たので、
envの参照は関数コールして読み込むように修正